### PR TITLE
Change the way of sending Accuracy enum value. 

### DIFF
--- a/Core/Sources/Model/ErrorInformation.swift
+++ b/Core/Sources/Model/ErrorInformation.swift
@@ -31,6 +31,11 @@ public enum ErrorInformationType {
     case trackableAlreadyExist(trackableId: String)
     
     /**
+     Thrown in case when Publisher has already stopped.
+     */
+    case publisherStoppedException
+    
+    /**
      Thrown in case of missing properties in builder
      */
     case incompleteConfiguration(missingProperty: String, forBuilderOption: String)
@@ -43,6 +48,7 @@ public enum ErrorInformationType {
         case .JSONCodingError(let object): return "Error while parsing: \(object)"
         case .incompleteConfiguration(let missingProperty, let builderOption): return "Missing mandatory property: \(missingProperty). Did you forgot to call `\(builderOption)` on builder object?"
         case .trackableAlreadyExist(let trackableId): return "Trackable with id: \(trackableId) already exist."
+        case .publisherStoppedException: return "Cannot perform this action when publisher is stopped."
         }
     }
 }

--- a/Core/Sources/ResolutionPolicy/Accuracy.swift
+++ b/Core/Sources/ResolutionPolicy/Accuracy.swift
@@ -1,16 +1,24 @@
+private enum AccuracyKeys: String {
+    case minimum = "MINIMUM_ACCURACY"
+    case low = "LOW_ACCURACY"
+    case balanced = "BALANCED_ACCURACY"
+    case high = "HIGH_ACCURACY"
+    case maximum = "MAXIMUM_ACCURACY"
+}
+
 /**
  The accuracy of a geographical coordinate.
  Presents a unified representation of location accuracy (Apple) and quality priority (Android).
  */
 @objc
-public enum Accuracy: Int, Codable {
+public enum Accuracy: Int {
     /**
      - Android: [PRIORITY_NO_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#PRIORITY_NO_POWER)
      (best possible with zero additional power consumption)
      - Apple: [kCLLocationAccuracyReduced](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyreduced)
      (preserves the user’s country, typically preserves the city, and is usually within 1–20 kilometers of the actual location)
      */
-    case minimum = 1
+    case minimum
 
     /**
      - Android: [PRIORITY_LOW_POWER](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#PRIORITY_LOW_POWER)
@@ -18,14 +26,14 @@ public enum Accuracy: Int, Codable {
      - Apple: Either [kCLLocationAccuracyKilometer](https://developer.apple.com/documentation/corelocation/kcllocationaccuracykilometer)
      or [kCLLocationAccuracyThreeKilometers](https://developer.apple.com/documentation/corelocation/kcllocationaccuracythreekilometers)
      */
-    case low = 2
+    case low
 
     /**
      - Android: [PRIORITY_BALANCED_POWER_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#PRIORITY_BALANCED_POWER_*   (coarse "block" level, circa 100m accuracy)
      - Apple: Either [kCLLocationAccuracyNearestTenMeters](https://developer.apple.com/documentation/corelocation/kcllocationaccuracynearesttenmeters)
      or [kCLLocationAccuracyHundredMeters](https://developer.apple.com/documentation/corelocation/kcllocationaccuracyhundredmeters)
      */
-    case balanced = 3
+    case balanced
 
     /**
      - Android: [PRIORITY_HIGH_ACCURACY](https://developers.google.com/android/reference/com/google/android/gms/location/LocationRequest#PRIORITY_HIGH_ACCURACY)
@@ -33,12 +41,67 @@ public enum Accuracy: Int, Codable {
      - Apple: [kCLLocationAccuracyBest](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybest)
      (very high accuracy but not to the same level required for navigation apps)
      */
-    case high = 4
+    case high
 
     /**
      - Android: same as `HIGH`
      - Apple: [kCLLocationAccuracyBestForNavigation](https://developer.apple.com/documentation/corelocation/kcllocationaccuracybestfornavigation)
      (precise position information required at all times, with significant extra power requirement implication)
      */
-    case maximum = 5
+    case maximum
+}
+
+extension Accuracy: Codable, RawRepresentable {
+    public typealias RawValue = String
+
+    public var rawValue: String {
+        switch self {
+        case .minimum: return AccuracyKeys.minimum.rawValue
+        case .low: return AccuracyKeys.low.rawValue
+        case .balanced: return AccuracyKeys.balanced.rawValue
+        case .high: return AccuracyKeys.high.rawValue
+        case .maximum: return AccuracyKeys.maximum.rawValue
+        }
+    }
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case AccuracyKeys.minimum.rawValue:
+            self = .minimum
+        case AccuracyKeys.low.rawValue:
+            self = .low
+        case AccuracyKeys.balanced.rawValue:
+            self = .balanced
+        case AccuracyKeys.high.rawValue:
+            self = .high
+        case AccuracyKeys.maximum.rawValue:
+            self = .maximum
+        default:
+            return nil
+        }
+    }
+}
+
+extension Accuracy: Comparable, Equatable {
+    private var index: Int {
+        switch self {
+        case .minimum: return 1
+        case .low: return 2
+        case .balanced: return 3
+        case .high: return 4
+        case .maximum: return 5
+        }
+    }
+    
+    public static func < (lhs: Accuracy, rhs: Accuracy) -> Bool {
+        return lhs.index < rhs.index
+    }
+    
+    public static func > (lhs: Accuracy, rhs: Accuracy) -> Bool {
+        return lhs.index > rhs.index
+    }
+    
+    public static func == (lhs: Accuracy, rhs: Accuracy) -> Bool {
+        return lhs.index == rhs.index
+    }
 }

--- a/Publisher/Sources/DefaultPublisher.swift
+++ b/Publisher/Sources/DefaultPublisher.swift
@@ -17,6 +17,7 @@ class DefaultPublisher: Publisher {
     private let resolutionPolicy: ResolutionPolicy
     private let routeProvider: RouteProvider
     private let batteryLevelProvider: BatteryLevelProvider
+    private var isStopped: Bool = false
 
     // ResolutionPolicy
     private let hooks: DefaultResolutionPolicyHooks
@@ -95,8 +96,8 @@ class DefaultPublisher: Publisher {
         enqueue(event: event)
     }
     
-    func close(completion: @escaping ResultHandler<Void>) {
-        let event = CloseEvent(resultHandler: completion)
+    func stop(completion: @escaping ResultHandler<Void>) {
+        let event = StopEvent(resultHandler: completion)
         enqueue(event: event)
     }
 }
@@ -151,8 +152,8 @@ extension DefaultPublisher: PublisherObjectiveC {
     }
     
     @objc
-    func close(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) {
-        self.close { result in
+    func stop(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void)) {
+        self.stop { result in
             switch result {
             case .success:
                 onSuccess()
@@ -168,6 +169,16 @@ extension DefaultPublisher {
     private func enqueue(event: PublisherEvent) {
         logger.trace("Received event: \(event)")
         performOnWorkingThread { [weak self] in
+            if self?.isStopped ?? true {
+                guard let stopEvent = event as? StopEvent else {
+                    let error = ErrorInformation(type: .publisherStoppedException)
+                    self?.notifyDelegateDidFailWithError(error)
+                    return
+                }
+                self?.performStopPublisherEvent(stopEvent)
+                return
+            }
+            
             switch event {
             case let event as TrackTrackableEvent: self?.performTrackTrackableEvent(event)
             case let event as PresenceJoinedSuccessfullyEvent: self?.performPresenceJoinedSuccessfullyEvent(event)
@@ -186,7 +197,7 @@ extension DefaultPublisher {
             case let event as DelegateConnectionStateChangedEvent: self?.notifyDelegateConnectionStateChanged(event)
             case let event as DelegateEnhancedLocationChangedEvent: self?.notifyDelegateEnhancedLocationChanged(event)
             case let event as ChangeRoutingProfileEvent: self?.performChangeRoutingProfileEvent(event)
-            case let event as CloseEvent: self?.performClosePublisherEvent(event)
+            case let event as StopEvent: self?.performStopPublisherEvent(event)
             default: preconditionFailure("Unhandled event in DefaultPublisher: \(event) ")
             }
         }
@@ -194,10 +205,6 @@ extension DefaultPublisher {
 
     private func callback<T: Any>(value: T, handler: @escaping ResultHandler<T>) {
         performOnMainThread { handler(.success(value)) }
-    }
-
-    private func callback(_ handler: @escaping ResultHandler<Bool>) {
-        performOnMainThread { handler(.success(true)) }
     }
 
     private func callback<T: Any>(error: ErrorInformation, handler: @escaping ResultHandler<T>) {
@@ -338,9 +345,22 @@ extension DefaultPublisher {
     }
     
     // MARK: Stop publisher
-    private func performClosePublisherEvent(_ event: CloseEvent) {
-        locationService.stopUpdatingLocation()
-        ablyService.close(completion: event.resultHandler)
+    private func performStopPublisherEvent(_ event: StopEvent) {
+        if isStopped {
+            callback(value: Void(), handler: event.resultHandler)
+            return
+        }
+        
+        ablyService.close { [weak self] result in
+            switch result {
+            case .success:
+                self?.locationService.stopUpdatingLocation()
+                self?.isStopped = true
+                self?.callback(value: Void(), handler: event.resultHandler)
+            case .failure(let error):
+                self?.callback(error: error, handler: event.resultHandler)
+            }
+        }
     }
 
     private func performClearRemovedTrackableMetadataEvent(_ event: ClearRemovedTrackableMetadataEvent) {

--- a/Publisher/Sources/DefaultPublisherEvents.swift
+++ b/Publisher/Sources/DefaultPublisherEvents.swift
@@ -63,7 +63,7 @@ struct PresenceUpdateEvent: PublisherEvent {
     let clientId: String
 }
 
-struct CloseEvent: PublisherEvent {
+struct StopEvent: PublisherEvent {
     let resultHandler: ResultHandler<Void>
 }
 

--- a/Publisher/Sources/DefaultResolutionPolicy/DefaultResolutionPolicy.swift
+++ b/Publisher/Sources/DefaultResolutionPolicy/DefaultResolutionPolicy.swift
@@ -73,7 +73,7 @@ class DefaultResolutionPolicy: ResolutionPolicy {
     }
 
     private func higher(_ lhs: Accuracy, _ rhs: Accuracy) -> Accuracy {
-        return lhs.rawValue > rhs.rawValue ? lhs : rhs
+        return lhs > rhs ? lhs : rhs
     }
 
     private func adjustToBatteryLevel(resolution: Resolution, constraints: DefaultResolutionConstraints) -> Resolution {

--- a/Publisher/Sources/Publisher.swift
+++ b/Publisher/Sources/Publisher.swift
@@ -78,7 +78,7 @@ public protocol PublisherObjectiveC: AnyObject {
      Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      */
     @objc
-    func close(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
+    func stop(onSuccess: @escaping (() -> Void), onError: @escaping ((ErrorInformation) -> Void))
 }
 
 /**
@@ -157,5 +157,5 @@ public protocol Publisher {
     /**
      Stops this publisher from publishing locations. Once a publisher has been stopped, it cannot be restarted.
      */
-    func close(completion: @escaping ResultHandler<Void>) 
+    func stop(completion: @escaping ResultHandler<Void>) 
 }

--- a/PublisherExample/Sources/Screens/Map/MapViewController.swift
+++ b/PublisherExample/Sources/Screens/Map/MapViewController.swift
@@ -123,12 +123,11 @@ class MapViewController: UIViewController {
     
     private func closePublisher(completion: ResultHandler<Void>?) {
         trackables.removeAll()
-        publisher?.close { [weak self] result in
+        publisher?.stop { [weak self] result in
             switch result {
             case .success:
                 logger.info("Publisher closed successfully.")
                 self?.locationState = .failed
-                self?.publisher = nil
                 completion?(.success(()))
             case .failure(let error):
                 logger.info("Publisher closing failed. Error: \(error.message).")
@@ -237,11 +236,6 @@ class MapViewController: UIViewController {
     
     @objc
     func onBackButtonPressed() {
-        guard publisher != nil else {
-            self.navigationController?.popViewController(animated: true)
-            return
-        }
-        
         closePublisher { result in
             switch result {
             case .success:


### PR DESCRIPTION
Change the way of sending Accuracy value from sending `Int` to `SCREAMING_CAMEL_CASE`ed `String`.

Old example:
`"accuracy": 1`

New example:
`"accuracy": "MINIMUM_ACCURACY"`

Closes #99.