### PR TITLE
Add prefix to Ably channel names

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		18F7B7D725B5AB9B0003E13C /* PresenceData_CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885CB5A25B5A27B000D8CAA /* PresenceData_CodableTests.swift */; };
 		2B2E929B8D92D774D39CE786 /* Pods_asset_tracking_CoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46DA6EC3262F21A4A8D436 /* Pods_asset_tracking_CoreTests.framework */; };
 		45E464C268419CCC6EFE41C1 /* Pods_asset_tracking_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB2F6D7125031B6DCA1EFE63 /* Pods_asset_tracking_Core.framework */; };
+		D94254E62655443E00BE98D8 /* Naming.swift in Sources */ = {isa = PBXBuildFile; fileRef = D94254E52655443E00BE98D8 /* Naming.swift */; };
 		F617C43125DA54AF005E92A2 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617C43025DA54AF005E92A2 /* ConnectionState.swift */; };
 		F65AC34125AF3E28002799BD /* RoutingProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65AC34025AF3E28002799BD /* RoutingProfile.swift */; };
 		F65C5CB325CA9F0500913A09 /* LocationUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65C5CB225CA9F0500913A09 /* LocationUpdate.swift */; };
@@ -96,6 +97,7 @@
 		75EF5D3EB9AF8EE52B9F5A8B /* Pods-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core.debug.xcconfig"; path = "Target Support Files/Pods-Core/Pods-Core.debug.xcconfig"; sourceTree = "<group>"; };
 		9AB07ED4116EBBAD484FF8A7 /* Pods-asset_tracking-CoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-CoreTests.release.xcconfig"; path = "Target Support Files/Pods-asset_tracking-CoreTests/Pods-asset_tracking-CoreTests.release.xcconfig"; sourceTree = "<group>"; };
 		B6779AD0ADA240AC512C4B24 /* Pods-CoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreTests.debug.xcconfig"; path = "Target Support Files/Pods-CoreTests/Pods-CoreTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D94254E52655443E00BE98D8 /* Naming.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Naming.swift; sourceTree = "<group>"; };
 		DB2F6D7125031B6DCA1EFE63 /* Pods_asset_tracking_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_asset_tracking_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE8D3F720FFF4D78877518EC /* Pods-asset_tracking-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-Core.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-Core/Pods-asset_tracking-Core.debug.xcconfig"; sourceTree = "<group>"; };
 		F617C43025DA54AF005E92A2 /* ConnectionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
@@ -301,6 +303,7 @@
 			isa = PBXGroup;
 			children = (
 				F688F9792613530B0051914A /* AblyPresence.swift */,
+				D94254E52655443E00BE98D8 /* Naming.swift */,
 			);
 			path = Ably;
 			sourceTree = "<group>";
@@ -514,6 +517,7 @@
 				180F6160258633C00014B310 /* ErrorInformation.swift in Sources */,
 				18C7B1B025B61349000A1418 /* Resolution.swift in Sources */,
 				18C7B1AF25B61349000A1418 /* Accuracy.swift in Sources */,
+				D94254E62655443E00BE98D8 /* Naming.swift in Sources */,
 				180F615A258633C00014B310 /* GeoJSONGeometry.swift in Sources */,
 				F6A2B75425E64DEB00153CF4 /* LocationValidator.swift in Sources */,
 				18C7B1AB25B61349000A1418 /* ResolutionPolicy.swift in Sources */,

--- a/Core/Sources/Model/Ably/Naming.swift
+++ b/Core/Sources/Model/Ably/Naming.swift
@@ -1,0 +1,8 @@
+/**
+ Returns a fully qualified channel name ready to be used with the core Ably library.
+ 
+ - Warning: This API should not be relied upon by app developers and is subject to change without notice.
+ */
+public func ablyChannelNameFromTrackableId(_ trackableId: String) -> String {
+    "tracking:\(trackableId)"
+}

--- a/Publisher/Sources/Services/DefaultAblyPublisherService.swift
+++ b/Publisher/Sources/Services/DefaultAblyPublisherService.swift
@@ -36,7 +36,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         // Force cast intentional here. It's a fatal error if we are unable to create presenceData JSON
         let data = try! presenceData.toJSONString()
 
-        let channel = client.channels.get(trackable.id)
+        let channel = client.channels.get(ablyChannelNameFromTrackableId(trackable.id))
         channel.presence.subscribe { [weak self] message in
             guard let self = self,
                   let json = message.data as? String,

--- a/Subscriber/Sources/Services/DefaultAblySubscriberService.swift
+++ b/Subscriber/Sources/Services/DefaultAblySubscriberService.swift
@@ -22,7 +22,7 @@ class DefaultAblySubscriberService: AblySubscriberService {
         self.presenceData = PresenceData(type: .subscriber, resolution: resolution)
         let options = ARTRealtimeChannelOptions()
         options.params = ["rewind": "1"]
-        channel = client.channels.get(trackingId, options: options)
+        channel = client.channels.get(ablyChannelNameFromTrackableId(trackingId), options: options)
         
         setup()
     }


### PR DESCRIPTION
Adds the `tracking:` prefix to all Ably channel names. Fixes #139.

See https://github.com/ably/ably-asset-tracking-android/pull/329.