### PR TITLE
`tracking` namespace added to each channel used for tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ archives/
 # User defined configuration
 Secrets.xcconfig
 PublisherExample/amplifyconfiguration.json
+
+# AppCode IDE
+.idea

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		18F7B7D725B5AB9B0003E13C /* PresenceData_CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885CB5A25B5A27B000D8CAA /* PresenceData_CodableTests.swift */; };
 		2B2E929B8D92D774D39CE786 /* Pods_asset_tracking_CoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46DA6EC3262F21A4A8D436 /* Pods_asset_tracking_CoreTests.framework */; };
 		45E464C268419CCC6EFE41C1 /* Pods_asset_tracking_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB2F6D7125031B6DCA1EFE63 /* Pods_asset_tracking_Core.framework */; };
+		AD5806992657FE73000BE2FB /* ARTRealtimeChannels+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD5806982657FE73000BE2FB /* ARTRealtimeChannels+Extensions.swift */; };
 		F617C43125DA54AF005E92A2 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617C43025DA54AF005E92A2 /* ConnectionState.swift */; };
 		F65AC34125AF3E28002799BD /* RoutingProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65AC34025AF3E28002799BD /* RoutingProfile.swift */; };
 		F65C5CB325CA9F0500913A09 /* LocationUpdate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65C5CB225CA9F0500913A09 /* LocationUpdate.swift */; };
@@ -95,6 +96,7 @@
 		741D5DE0555062288A31F129 /* Pods-asset_tracking-Core.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-Core.release.xcconfig"; path = "Target Support Files/Pods-asset_tracking-Core/Pods-asset_tracking-Core.release.xcconfig"; sourceTree = "<group>"; };
 		75EF5D3EB9AF8EE52B9F5A8B /* Pods-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core.debug.xcconfig"; path = "Target Support Files/Pods-Core/Pods-Core.debug.xcconfig"; sourceTree = "<group>"; };
 		9AB07ED4116EBBAD484FF8A7 /* Pods-asset_tracking-CoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-CoreTests.release.xcconfig"; path = "Target Support Files/Pods-asset_tracking-CoreTests/Pods-asset_tracking-CoreTests.release.xcconfig"; sourceTree = "<group>"; };
+		AD5806982657FE73000BE2FB /* ARTRealtimeChannels+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ARTRealtimeChannels+Extensions.swift"; sourceTree = "<group>"; };
 		B6779AD0ADA240AC512C4B24 /* Pods-CoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreTests.debug.xcconfig"; path = "Target Support Files/Pods-CoreTests/Pods-CoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		DB2F6D7125031B6DCA1EFE63 /* Pods_asset_tracking_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_asset_tracking_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DE8D3F720FFF4D78877518EC /* Pods-asset_tracking-Core.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-Core.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-Core/Pods-asset_tracking-Core.debug.xcconfig"; sourceTree = "<group>"; };
@@ -308,6 +310,7 @@
 		F688F996261354DE0051914A /* AblyExtensions */ = {
 			isa = PBXGroup;
 			children = (
+				AD5806982657FE73000BE2FB /* ARTRealtimeChannels+Extensions.swift */,
 				F688F997261354F70051914A /* ARTRealtimeChannelState+Extensions.swift */,
 				F688F99B2613550E0051914A /* ARTRealtimeConnectionState+Extensions.swift */,
 				F688F99F261355550051914A /* ARTErrorInfo+Extensions.swift */,
@@ -527,6 +530,7 @@
 				18C7B1AD25B61349000A1418 /* ResolutionConstraints.swift in Sources */,
 				180F615C258633C00014B310 /* GeoJSONType.swift in Sources */,
 				18A4C1C725B2E04D0092CC70 /* ResultHandler.swift in Sources */,
+				AD5806992657FE73000BE2FB /* ARTRealtimeChannels+Extensions.swift in Sources */,
 				F688F998261354F70051914A /* ARTRealtimeChannelState+Extensions.swift in Sources */,
 				18C7B1AC25B61349000A1418 /* TrackableResolutionRequest.swift in Sources */,
 				180F6156258633C00014B310 /* Decodable+FromJSONString.swift in Sources */,

--- a/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
+++ b/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
@@ -3,7 +3,7 @@ import Ably
 private let channelNamePrefix = "tracking"
 
 extension ARTRealtimeChannels {
-    public func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions? = nil) -> ARTRealtimeChannel {
+    func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions? = nil) -> ARTRealtimeChannel {
         let segments = [channelNamePrefix, trackingId]
         let channelName = segments.joined(separator: ":")
         if let options = options {

--- a/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
+++ b/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
@@ -1,10 +1,10 @@
 import Ably
 
-let CHANNEL_NAME_PREFIX = "tracking"
+private let channelNamePrefix = "tracking"
 
 extension ARTRealtimeChannels {
     public func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions? = nil) -> ARTRealtimeChannel {
-        let segments = [CHANNEL_NAME_PREFIX, trackingId]
+        let segments = [channelNamePrefix, trackingId]
         let channelName = segments.joined(separator: ":")
         if let options = options {
             return self.get(channelName, options: options);

--- a/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
+++ b/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
@@ -7,7 +7,7 @@ extension ARTRealtimeChannels {
         let segments = [trackingChannelNamespace, trackingId]
         let channelName = segments.joined(separator: ":")
         if let options = options {
-            return self.get(channelName, options: options);
+            return self.get(channelName, options: options)
         }
         return self.get(channelName)
     }

--- a/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
+++ b/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
@@ -1,10 +1,10 @@
 import Ably
 
-private let channelNamePrefix = "tracking"
+private let trackingChannelNamespace = "tracking"
 
 extension ARTRealtimeChannels {
     func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions? = nil) -> ARTRealtimeChannel {
-        let segments = [channelNamePrefix, trackingId]
+        let segments = [trackingChannelNamespace, trackingId]
         let channelName = segments.joined(separator: ":")
         if let options = options {
             return self.get(channelName, options: options);

--- a/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
+++ b/Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift
@@ -1,0 +1,14 @@
+import Ably
+
+let CHANNEL_NAME_PREFIX = "tracking"
+
+extension ARTRealtimeChannels {
+    public func getChannelFor(trackingId: String, options: ARTRealtimeChannelOptions? = nil) -> ARTRealtimeChannel {
+        let segments = [CHANNEL_NAME_PREFIX, trackingId]
+        let channelName = segments.joined(separator: ":")
+        if let options = options {
+            return self.get(channelName, options: options);
+        }
+        return self.get(channelName)
+    }
+}

--- a/Publisher/Publisher.xcodeproj/project.pbxproj
+++ b/Publisher/Publisher.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		18FCE1EB258B8264005BC480 /* Decodable+FromJSONString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FCE1DD258B8264005BC480 /* Decodable+FromJSONString.swift */; };
 		18FCE1EC258B8264005BC480 /* Codable+EncodedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FCE1DE258B8264005BC480 /* Codable+EncodedString.swift */; };
 		18FCE1ED258B8264005BC480 /* UnimplementedSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FCE1DF258B8264005BC480 /* UnimplementedSupport.swift */; };
+		ADA1EE3C265A4E7D00FCC669 /* ARTRealtimeChannels+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA1EE3B265A4E7D00FCC669 /* ARTRealtimeChannels+Extensions.swift */; };
 		BE1856D9ECD8A5729CCB72B2 /* Pods_asset_tracking_Publisher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 75FF3FC4C81DED6B6A5792B3 /* Pods_asset_tracking_Publisher.framework */; };
 		C2C546A210DC13668DE92C4E /* Pods_asset_tracking_PublisherTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5322F2D00ECE77D2B1F89D57 /* Pods_asset_tracking_PublisherTests.framework */; };
 		F617C43525DA5848005E92A2 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617C43425DA5848005E92A2 /* ConnectionState.swift */; };
@@ -161,6 +162,7 @@
 		867353D820CA23D64DD92663 /* Pods-PublisherTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PublisherTests.debug.xcconfig"; path = "Target Support Files/Pods-PublisherTests/Pods-PublisherTests.debug.xcconfig"; sourceTree = "<group>"; };
 		8B412391C99428EFFA9D511B /* Pods-asset_tracking-PublisherTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-PublisherTests.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-PublisherTests/Pods-asset_tracking-PublisherTests.debug.xcconfig"; sourceTree = "<group>"; };
 		96BA6252D49C6BAA02CFF7B7 /* Pods-Publisher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Publisher.release.xcconfig"; path = "Target Support Files/Pods-Publisher/Pods-Publisher.release.xcconfig"; sourceTree = "<group>"; };
+		ADA1EE3B265A4E7D00FCC669 /* ARTRealtimeChannels+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ARTRealtimeChannels+Extensions.swift"; path = "../Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift"; sourceTree = "<group>"; };
 		C8859F81CDD7390E11741B66 /* Pods-asset_tracking-Publisher.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-Publisher.release.xcconfig"; path = "Target Support Files/Pods-asset_tracking-Publisher/Pods-asset_tracking-Publisher.release.xcconfig"; sourceTree = "<group>"; };
 		F617C43425DA5848005E92A2 /* ConnectionState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectionState.swift; sourceTree = "<group>"; };
 		F656005A25DFAED100491E6A /* LocationSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSource.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 		180F608D258632510014B310 = {
 			isa = PBXGroup;
 			children = (
+				ADA1EE3B265A4E7D00FCC669 /* ARTRealtimeChannels+Extensions.swift */,
 				180F6099258632510014B310 /* Sources */,
 				180F6121258633140014B310 /* Tests */,
 				180F6098258632510014B310 /* Products */,
@@ -653,6 +656,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ADA1EE3C265A4E7D00FCC669 /* ARTRealtimeChannels+Extensions.swift in Sources */,
 				18FCE1ED258B8264005BC480 /* UnimplementedSupport.swift in Sources */,
 				18FCE1E0258B8264005BC480 /* ConnectionConfiguration.swift in Sources */,
 				F688F9BA261355BB0051914A /* ARTRealtimeChannelState+Extensions.swift in Sources */,

--- a/Publisher/Sources/Services/DefaultAblyPublisherService.swift
+++ b/Publisher/Sources/Services/DefaultAblyPublisherService.swift
@@ -36,7 +36,7 @@ class DefaultAblyPublisherService: AblyPublisherService {
         // Force cast intentional here. It's a fatal error if we are unable to create presenceData JSON
         let data = try! presenceData.toJSONString()
 
-        let channel = client.channels.get(trackable.id)
+        let channel = client.channels.getChannelFor(trackingId: trackable.id)
         channel.presence.subscribe { [weak self] message in
             guard let self = self,
                   let json = message.data as? String,

--- a/Subscriber/Sources/Services/DefaultAblySubscriberService.swift
+++ b/Subscriber/Sources/Services/DefaultAblySubscriberService.swift
@@ -22,7 +22,7 @@ class DefaultAblySubscriberService: AblySubscriberService {
         self.presenceData = PresenceData(type: .subscriber, resolution: resolution)
         let options = ARTRealtimeChannelOptions()
         options.params = ["rewind": "1"]
-        channel = client.channels.get(trackingId, options: options)
+        channel = client.channels.getChannelFor(trackingId: trackingId, options: options)
         
         setup()
     }

--- a/Subscriber/Subscriber.xcodeproj/project.pbxproj
+++ b/Subscriber/Subscriber.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		18FCE210258B8336005BC480 /* UnimplementedSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18FCE202258B8336005BC480 /* UnimplementedSupport.swift */; };
 		1F9298B18A4CD0599098401B /* Pods_asset_tracking_SubscriberTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8CCB14452A0115A255689664 /* Pods_asset_tracking_SubscriberTests.framework */; };
 		2375C3D9FBC87E4236B66FA6 /* Pods_asset_tracking_Subscriber.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B94C2AA15165F9680C282FE /* Pods_asset_tracking_Subscriber.framework */; };
+		ADA1EE3E265A4E9E00FCC669 /* ARTRealtimeChannels+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADA1EE3D265A4E9E00FCC669 /* ARTRealtimeChannels+Extensions.swift */; };
 		F617C46925DA5EF9005E92A2 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617C46825DA5EF9005E92A2 /* ConnectionState.swift */; };
 		F63F8FE7260B4BCB009B5353 /* MockAblySubscriberService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63F8FDC260B48F0009B5353 /* MockAblySubscriberService.swift */; };
 		F63F8FEC260B4BCE009B5353 /* DefaultSubscriberTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F63F8FD3260B36C4009B5353 /* DefaultSubscriberTests.swift */; };
@@ -103,6 +104,7 @@
 		8E84C9527E90EEB26AA8FE61 /* Pods-asset_tracking-Subscriber.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-Subscriber.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-Subscriber/Pods-asset_tracking-Subscriber.debug.xcconfig"; sourceTree = "<group>"; };
 		A243740C463C9796525DDC55 /* Pods-Subscriber.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Subscriber.release.xcconfig"; path = "Target Support Files/Pods-Subscriber/Pods-Subscriber.release.xcconfig"; sourceTree = "<group>"; };
 		A77BDA31C9F103BB99CE1A31 /* Pods-Subscriber.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Subscriber.debug.xcconfig"; path = "Target Support Files/Pods-Subscriber/Pods-Subscriber.debug.xcconfig"; sourceTree = "<group>"; };
+		ADA1EE3D265A4E9E00FCC669 /* ARTRealtimeChannels+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "ARTRealtimeChannels+Extensions.swift"; path = "../Core/Sources/AblyExtensions/ARTRealtimeChannels+Extensions.swift"; sourceTree = "<group>"; };
 		B0C194B8C93C37753B28F4C4 /* Pods-SubscriberTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubscriberTests.debug.xcconfig"; path = "Target Support Files/Pods-SubscriberTests/Pods-SubscriberTests.debug.xcconfig"; sourceTree = "<group>"; };
 		B35382D91FBE9FB98C137BB8 /* Pods-asset_tracking-SubscriberTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-SubscriberTests.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-SubscriberTests/Pods-asset_tracking-SubscriberTests.debug.xcconfig"; sourceTree = "<group>"; };
 		DACEA3FB594D43A74240A868 /* Pods-SubscriberTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SubscriberTests.release.xcconfig"; path = "Target Support Files/Pods-SubscriberTests/Pods-SubscriberTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -161,6 +163,7 @@
 		180F60A3258632740014B310 = {
 			isa = PBXGroup;
 			children = (
+				ADA1EE3D265A4E9E00FCC669 /* ARTRealtimeChannels+Extensions.swift */,
 				180F60AF258632740014B310 /* Sources */,
 				180F61302586332B0014B310 /* Tests */,
 				180F60AE258632740014B310 /* Products */,
@@ -543,6 +546,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				ADA1EE3E265A4E9E00FCC669 /* ARTRealtimeChannels+Extensions.swift in Sources */,
 				18FCE20E258B8336005BC480 /* Decodable+FromJSONString.swift in Sources */,
 				F617C46925DA5EF9005E92A2 /* ConnectionState.swift in Sources */,
 				18FCE20C258B8336005BC480 /* EventName.swift in Sources */,


### PR DESCRIPTION
I guess this is why this ticket exists, but I might be wrong:
Currently, users need to add the persistence channel rule for each tracking ID in the Ably.com application dashboard. With this, they only need to add the persistence channel rule to the `tracking` namespace once on Ably.com.

Very similar to https://github.com/ably/ably-asset-tracking-cocoa/pull/143 but I used extensions.

Please also let me know if this should be tested.

Closes https://github.com/ably/ably-asset-tracking-cocoa/issues/139