### PR TITLE
Make battery level optional in EnhancedLocationUpdateMessage

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		18C7B1AF25B61349000A1418 /* Accuracy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C7B1A925B61349000A1418 /* Accuracy.swift */; };
 		18C7B1B025B61349000A1418 /* Resolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18C7B1AA25B61349000A1418 /* Resolution.swift */; };
 		18F7B7D725B5AB9B0003E13C /* PresenceData_CodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1885CB5A25B5A27B000D8CAA /* PresenceData_CodableTests.swift */; };
+		1D6A36CB8DD63C322F77C7B1 /* EnhancedLocationUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6A30380DA5F2D59F2DE559 /* EnhancedLocationUpdateTests.swift */; };
 		2B2E929B8D92D774D39CE786 /* Pods_asset_tracking_CoreTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A46DA6EC3262F21A4A8D436 /* Pods_asset_tracking_CoreTests.framework */; };
 		45E464C268419CCC6EFE41C1 /* Pods_asset_tracking_Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DB2F6D7125031B6DCA1EFE63 /* Pods_asset_tracking_Core.framework */; };
 		F617C43125DA54AF005E92A2 /* ConnectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F617C43025DA54AF005E92A2 /* ConnectionState.swift */; };
@@ -89,6 +90,7 @@
 		18C7B1A825B61349000A1418 /* Proximity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Proximity.swift; sourceTree = "<group>"; };
 		18C7B1A925B61349000A1418 /* Accuracy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Accuracy.swift; sourceTree = "<group>"; };
 		18C7B1AA25B61349000A1418 /* Resolution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resolution.swift; sourceTree = "<group>"; };
+		1D6A30380DA5F2D59F2DE559 /* EnhancedLocationUpdateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EnhancedLocationUpdateTests.swift; sourceTree = "<group>"; };
 		35A374438110A61B786B1EEE /* Pods-Core.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Core.release.xcconfig"; path = "Target Support Files/Pods-Core/Pods-Core.release.xcconfig"; sourceTree = "<group>"; };
 		58262A249E17B4E4FC6049FA /* Pods-asset_tracking-CoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-asset_tracking-CoreTests.debug.xcconfig"; path = "Target Support Files/Pods-asset_tracking-CoreTests/Pods-asset_tracking-CoreTests.debug.xcconfig"; sourceTree = "<group>"; };
 		69B3E7FEA13419A414562A29 /* Pods-CoreTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CoreTests.release.xcconfig"; path = "Target Support Files/Pods-CoreTests/Pods-CoreTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -242,6 +244,7 @@
 				180F616A2586340D0014B310 /* GeoJSON */,
 				1885CB5A25B5A27B000D8CAA /* PresenceData_CodableTests.swift */,
 				F66491BC25E909BE0035F45A /* TrackableTests.swift */,
+				1D6A30380DA5F2D59F2DE559 /* EnhancedLocationUpdateTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -553,6 +556,7 @@
 				F68E171E25E79B0C009AECEB /* GeoJSONGeometryCodableTests.swift in Sources */,
 				F68E172425E79D8E009AECEB /* GeoJSONGeometryCLLocationTests.swift in Sources */,
 				F6DC46C125E78C74002E7691 /* GeoJSONMessageCLLocationTests.swift in Sources */,
+				1D6A36CB8DD63C322F77C7B1 /* EnhancedLocationUpdateTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Core/Sources/Model/LocationUpdate.swift
+++ b/Core/Sources/Model/LocationUpdate.swift
@@ -25,13 +25,13 @@ public class EnhancedLocationUpdate {
 
 public class EnhancedLocationUpdateMessage: Codable {
     let location: GeoJSONMessage
-    let batteryLevel: Float
+    let batteryLevel: Float?
     let intermediateLocations: [GeoJSONMessage]
     let type: LocationUpdateType
 
     init(locationUpdate: EnhancedLocationUpdate, batteryLevel: Float?) throws {
         self.location = try GeoJSONMessage(location: locationUpdate.location)
-        self.batteryLevel = batteryLevel ?? 0
+        self.batteryLevel = batteryLevel
         self.intermediateLocations = []
         self.type = locationUpdate.type
     }

--- a/Core/Tests/Sources/Model/EnhancedLocationUpdateTests.swift
+++ b/Core/Tests/Sources/Model/EnhancedLocationUpdateTests.swift
@@ -1,0 +1,22 @@
+import Foundation
+import CoreLocation
+import XCTest
+@testable import Core
+
+class EnhancedLocationUpdateTests: XCTestCase {
+
+    func testEnhancedLocationUpdateMessageDecodesNullBatteryLevel() throws {
+        let location = CLLocation(latitude: 0.0, longitude: 0.0)
+        let expected = try! EnhancedLocationUpdateMessage(locationUpdate: EnhancedLocationUpdate(location: location), batteryLevel: nil)
+        
+        let jsonString = try! expected.toJSONString()
+        let actual: EnhancedLocationUpdateMessage = try! EnhancedLocationUpdateMessage.fromJSONString(jsonString)
+        
+        XCTAssertEqual(expected.batteryLevel, actual.batteryLevel)
+        XCTAssertEqual(expected.type, actual.type)
+        
+// There are more things to XCTAssertEqual but you'll need to implement Equatable or start using Structs instead of classes.
+//        XCTAssertEqual(expected.location, actual.location)
+//        XCTAssertEqual(expected.intermediateLocations, expected.intermediateLocations)
+    }
+}


### PR DESCRIPTION
This allows `EnhancedLocationUpdateMessage` to be optional, to receive messages from other libraries (e.g. Android) without crashing.

From @KacperKluka in Slack messages: https://ably-real-time.slack.com/archives/C01EPJENRD0/p1621852415046500:
> In the `EnhancedLocationUpdateMessage` the batteryLevel is just a Float which means it doesn't accept null. For parsing JSON we're using JSONDecoder.decode() which throws an error if the data isn't of the expected type. This means that if in the JSON message the `batteryLevel` will be null or missing then the decoder will fail. Luckily, the app won't crash in this case as we're handling such error in the code. However, all location updates without battery level will get lost making the iOS subscriber useless if the publisher is started on Android :confused: To fix it we should change the batter level type to `Float?` which accepts nulls.

An example error when decoding a JSON string:
```
**Swift.DecodingError.valueNotFound(Swift.String, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "first", intValue: nil)], debugDescription: "Expected String value but found null instead.", underlyingError: nil)**
```

