### PR TITLE
Update links from ably-asset-tracking-cocoa to Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,54 @@
 # Changelog
 
 
-## [1.0.0-beta.1](https://github.com/ably/ably-asset-tracking-cocoa/tree/v1.0.0-beta.1)
+## [1.0.0-beta.1](https://github.com/ably/ably-asset-tracking-swift/tree/v1.0.0-beta.1)
 
-[Full Changelog](https://github.com/ably/ably-asset-tracking-cocoa/compare/v1.0.0-preview.2...v1.0.0-beta.1)
-
-**Closed issues:**
-
-- Setup CocoaPods-Keys or similar tool to manage apiKeys locally [\#25](https://github.com/ably/ably-asset-tracking-cocoa/issues/25)
-
-**Merged pull requests:**
-
-- \[ATS-119\] Set up secrets using .xcconfig file. [\#78](https://github.com/ably/ably-asset-tracking-cocoa/pull/78) ([robertkuraj](https://github.com/robertkuraj))
-- Add maintainers file [\#72](https://github.com/ably/ably-asset-tracking-cocoa/pull/72) ([niksilver](https://github.com/niksilver))
-- \[ATS-180\] Displaying resolution info in PublisherExample app. [\#67](https://github.com/ably/ably-asset-tracking-cocoa/pull/67) ([robertkuraj](https://github.com/robertkuraj))
-- \[ATS-179\] Setting and changing RoutingProfile in Publisher. [\#61](https://github.com/ably/ably-asset-tracking-cocoa/pull/61) ([robertkuraj](https://github.com/robertkuraj))
-- \[ATS-178\] Request resolution change from Subscriber Example app [\#60](https://github.com/ably/ably-asset-tracking-cocoa/pull/60) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-183\] Add support for adding multiple assets in Publisher Example App [\#59](https://github.com/ably/ably-asset-tracking-cocoa/pull/59) ([mmiedlarz](https://github.com/mmiedlarz))
-
-## [1.0.0-preview.2](https://github.com/ably/ably-asset-tracking-cocoa/tree/v1.0.0-preview.2)
-
-[Full Changelog](https://github.com/ably/ably-asset-tracking-cocoa/compare/v1.0.0-preview.1...v1.0.0-preview.2)
+[Full Changelog](https://github.com/ably/ably-asset-tracking-swift/compare/v1.0.0-preview.2...v1.0.0-beta.1)
 
 **Closed issues:**
 
-- Incorrect bundle/package namespace prefix [\#62](https://github.com/ably/ably-asset-tracking-cocoa/issues/62)
-- Add Coding Conventions and Style Guide section to the Readme [\#36](https://github.com/ably/ably-asset-tracking-cocoa/issues/36)
-- Use .xcodeproj instead of targets for managing SDKs [\#34](https://github.com/ably/ably-asset-tracking-cocoa/issues/34)
-- Adopt unified threading strategy [\#26](https://github.com/ably/ably-asset-tracking-cocoa/issues/26)
-- Use dedicated logger in SDKs [\#8](https://github.com/ably/ably-asset-tracking-cocoa/issues/8)
+- Setup CocoaPods-Keys or similar tool to manage apiKeys locally [\#25](https://github.com/ably/ably-asset-tracking-swift/issues/25)
 
 **Merged pull requests:**
 
-- Add missing schemes for example apps. [\#70](https://github.com/ably/ably-asset-tracking-cocoa/pull/70) ([robertkuraj](https://github.com/robertkuraj))
-- \[ATS-139\] Calculate Route [\#58](https://github.com/ably/ably-asset-tracking-cocoa/pull/58) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-130\] Update readme [\#57](https://github.com/ably/ably-asset-tracking-cocoa/pull/57) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-140\] Use resolution policy in Subscriber  [\#56](https://github.com/ably/ably-asset-tracking-cocoa/pull/56) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-137\] DefaultResolutionPolicy [\#55](https://github.com/ably/ably-asset-tracking-cocoa/pull/55) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-138\] DefaultPublisher - Tests [\#54](https://github.com/ably/ably-asset-tracking-cocoa/pull/54) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-138\] Add support for tracking multiple trackables [\#53](https://github.com/ably/ably-asset-tracking-cocoa/pull/53) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-121\] Event based threading in Subscriber SDK [\#50](https://github.com/ably/ably-asset-tracking-cocoa/pull/50) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-121\] Publisher - Event base threading [\#49](https://github.com/ably/ably-asset-tracking-cocoa/pull/49) ([mmiedlarz](https://github.com/mmiedlarz))
-- Add CodeCoverage reports using slather [\#48](https://github.com/ably/ably-asset-tracking-cocoa/pull/48) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-136\] Resolution policy interfaces [\#47](https://github.com/ably/ably-asset-tracking-cocoa/pull/47) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-94\] SwiftLog logger [\#46](https://github.com/ably/ably-asset-tracking-cocoa/pull/46) ([mmiedlarz](https://github.com/mmiedlarz))
-- Use accuracy parameter while comparing doubles in GeoJSON [\#45](https://github.com/ably/ably-asset-tracking-cocoa/pull/45) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-126\] Use CocoaPods to install Publisher and Subscriber SDKs in Example Apps [\#42](https://github.com/ably/ably-asset-tracking-cocoa/pull/42) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-126\] Run app on the physical device [\#39](https://github.com/ably/ably-asset-tracking-cocoa/pull/39) ([mmiedlarz](https://github.com/mmiedlarz))
-- \[ATS-126\] Use xcodeproj instead of target [\#38](https://github.com/ably/ably-asset-tracking-cocoa/pull/38) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-119\] Set up secrets using .xcconfig file. [\#78](https://github.com/ably/ably-asset-tracking-swift/pull/78) ([robertkuraj](https://github.com/robertkuraj))
+- Add maintainers file [\#72](https://github.com/ably/ably-asset-tracking-swift/pull/72) ([niksilver](https://github.com/niksilver))
+- \[ATS-180\] Displaying resolution info in PublisherExample app. [\#67](https://github.com/ably/ably-asset-tracking-swift/pull/67) ([robertkuraj](https://github.com/robertkuraj))
+- \[ATS-179\] Setting and changing RoutingProfile in Publisher. [\#61](https://github.com/ably/ably-asset-tracking-swift/pull/61) ([robertkuraj](https://github.com/robertkuraj))
+- \[ATS-178\] Request resolution change from Subscriber Example app [\#60](https://github.com/ably/ably-asset-tracking-swift/pull/60) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-183\] Add support for adding multiple assets in Publisher Example App [\#59](https://github.com/ably/ably-asset-tracking-swift/pull/59) ([mmiedlarz](https://github.com/mmiedlarz))
 
-## [1.0.0-preview.1](https://github.com/ably/ably-asset-tracking-cocoa/tree/v1.0.0-preview.1)
+## [1.0.0-preview.2](https://github.com/ably/ably-asset-tracking-swift/tree/v1.0.0-preview.2)
+
+[Full Changelog](https://github.com/ably/ably-asset-tracking-swift/compare/v1.0.0-preview.1...v1.0.0-preview.2)
+
+**Closed issues:**
+
+- Incorrect bundle/package namespace prefix [\#62](https://github.com/ably/ably-asset-tracking-swift/issues/62)
+- Add Coding Conventions and Style Guide section to the Readme [\#36](https://github.com/ably/ably-asset-tracking-swift/issues/36)
+- Use .xcodeproj instead of targets for managing SDKs [\#34](https://github.com/ably/ably-asset-tracking-swift/issues/34)
+- Adopt unified threading strategy [\#26](https://github.com/ably/ably-asset-tracking-swift/issues/26)
+- Use dedicated logger in SDKs [\#8](https://github.com/ably/ably-asset-tracking-swift/issues/8)
+
+**Merged pull requests:**
+
+- Add missing schemes for example apps. [\#70](https://github.com/ably/ably-asset-tracking-swift/pull/70) ([robertkuraj](https://github.com/robertkuraj))
+- \[ATS-139\] Calculate Route [\#58](https://github.com/ably/ably-asset-tracking-swift/pull/58) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-130\] Update readme [\#57](https://github.com/ably/ably-asset-tracking-swift/pull/57) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-140\] Use resolution policy in Subscriber  [\#56](https://github.com/ably/ably-asset-tracking-swift/pull/56) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-137\] DefaultResolutionPolicy [\#55](https://github.com/ably/ably-asset-tracking-swift/pull/55) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-138\] DefaultPublisher - Tests [\#54](https://github.com/ably/ably-asset-tracking-swift/pull/54) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-138\] Add support for tracking multiple trackables [\#53](https://github.com/ably/ably-asset-tracking-swift/pull/53) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-121\] Event based threading in Subscriber SDK [\#50](https://github.com/ably/ably-asset-tracking-swift/pull/50) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-121\] Publisher - Event base threading [\#49](https://github.com/ably/ably-asset-tracking-swift/pull/49) ([mmiedlarz](https://github.com/mmiedlarz))
+- Add CodeCoverage reports using slather [\#48](https://github.com/ably/ably-asset-tracking-swift/pull/48) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-136\] Resolution policy interfaces [\#47](https://github.com/ably/ably-asset-tracking-swift/pull/47) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-94\] SwiftLog logger [\#46](https://github.com/ably/ably-asset-tracking-swift/pull/46) ([mmiedlarz](https://github.com/mmiedlarz))
+- Use accuracy parameter while comparing doubles in GeoJSON [\#45](https://github.com/ably/ably-asset-tracking-swift/pull/45) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-126\] Use CocoaPods to install Publisher and Subscriber SDKs in Example Apps [\#42](https://github.com/ably/ably-asset-tracking-swift/pull/42) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-126\] Run app on the physical device [\#39](https://github.com/ably/ably-asset-tracking-swift/pull/39) ([mmiedlarz](https://github.com/mmiedlarz))
+- \[ATS-126\] Use xcodeproj instead of target [\#38](https://github.com/ably/ably-asset-tracking-swift/pull/38) ([mmiedlarz](https://github.com/mmiedlarz))
+
+## [1.0.0-preview.1](https://github.com/ably/ably-asset-tracking-swift/tree/v1.0.0-preview.1)
 
 Initial preview release.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Ably Asset Tracking SDKs for Cocoa
 
-![.github/workflows/check.yml](https://github.com/ably/ably-asset-tracking-cocoa/workflows/.github/workflows/check.yml/badge.svg)
+![.github/workflows/check.yml](https://github.com/ably/ably-asset-tracking-swift/workflows/.github/workflows/check.yml/badge.svg)
 
 ## Overview
 
 Ably Asset Tracking SDKs provide an easy way to track multiple assets with realtime location updates powered by [Ably](https://ably.com/) realtime network and Mapbox [Navigation SDK](https://docs.mapbox.com/android/navigation/overview/) with location enhancement.
 
-**Status:** this is a beta version of the SDKs. That means that it contains a subset of the final SDK functionality, and the APIs are subject to change. The latest release of the SDKs is available in the [Releases section](https://github.com/ably/ably-asset-tracking-cocoa/releases) of this repository.
+**Status:** this is a beta version of the SDKs. That means that it contains a subset of the final SDK functionality, and the APIs are subject to change. The latest release of the SDKs is available in the [Releases section](https://github.com/ably/ably-asset-tracking-swift/releases) of this repository.
 
 Ably Asset Tracking is:
 
@@ -47,15 +47,15 @@ Visit the [Ably Asset Tracking](https://ably.com/documentation/asset-tracking) d
 - To use the Asset Tracking Publisher or Subscriber SDKs, add the relevant following lines to your Podfile
   ```
   target 'Your App Name' do
-    pod 'AblyAssetTracking/Publisher', :git => 'https://github.com/ably/ably-asset-tracking-cocoa' // To use the Publisher SDK
-    pod 'AblyAssetTracking/Subscriber', :git => 'https://github.com/ably/ably-asset-tracking-cocoa' // To use the Subscriber SDK
+    pod 'AblyAssetTracking/Publisher', :git => 'https://github.com/ably/ably-asset-tracking-swift' // To use the Publisher SDK
+    pod 'AblyAssetTracking/Subscriber', :git => 'https://github.com/ably/ably-asset-tracking-swift' // To use the Subscriber SDK
   end
   ```
 - `pod install`
 
 ### Swift package manager
 
-Not currently supported, but [planned](https://github.com/ably/ably-asset-tracking-cocoa/issues/148).
+Not currently supported, but [planned](https://github.com/ably/ably-asset-tracking-swift/issues/148).
 
 ## Usage
 
@@ -193,7 +193,7 @@ Additionally, when you run tests using `Fastlane` you will see three new directo
 
 ### Working on code shared between Publisher and Subscriber
 
-To speed up CocoaPods setup we removed framework/project linking in Xcode and we're just referencing files from the `Core` framework in `Publisher` and `Subscriber` SDK. There is a [ticket](https://github.com/ably/ably-asset-tracking-cocoa/issues/43) to fix it in the future, but for now, if you need to add or move any file in the `Core` SDK make sure that you also reference them in `Publisher` and `Subscriber`.
+To speed up CocoaPods setup we removed framework/project linking in Xcode and we're just referencing files from the `Core` framework in `Publisher` and `Subscriber` SDK. There is a [ticket](https://github.com/ably/ably-asset-tracking-swift/issues/43) to fix it in the future, but for now, if you need to add or move any file in the `Core` SDK make sure that you also reference them in `Publisher` and `Subscriber`.
 
 ### Release Procedure
 


### PR DESCRIPTION
Part of work from renaming ably-asset-tracking-cocoa to ably-asset-tracking-swift at ably/ably-asset-tracking-cocoa#151